### PR TITLE
Add Meta+Return

### DIFF
--- a/src/key-string-detector.js
+++ b/src/key-string-detector.js
@@ -16,6 +16,9 @@ export default class KeyStringDetector {
     if (event.altKey) {
       keyString = `Alt+${keyString}`;
     }
+    if (event.metaKey) {
+      keyString = `Meta+${keyString}`;
+    }
     keyString += keyStringMap[event.keyCode] || 'Unknown';
     return keyString;
   }

--- a/test/key-string-detector.test.js
+++ b/test/key-string-detector.test.js
@@ -33,7 +33,14 @@ describe('KeyStringDetector', () => {
       );
     });
 
-    it('detects Unknown', () => {
+    it('detects Meta+Return', () => {
+      assert.equal(
+        detector.detect({ metaKey: true, keyCode: 13 }),
+        'Meta+Return'
+      );
+    });
+
+   it('detects Unknown', () => {
       assert.equal(
         detector.detect({ keyCode: 0 }),
         'Unknown'


### PR DESCRIPTION
> On Macintosh keyboards, this is the command key (⌘).
> On Windows keyboards, this is the windows key (⊞).

https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/metaKey
